### PR TITLE
Fix caching of predefined list field

### DIFF
--- a/libraries/joomla/form/fields/predefinedlist.php
+++ b/libraries/joomla/form/fields/predefinedlist.php
@@ -60,7 +60,7 @@ abstract class JFormFieldPredefinedList extends JFormFieldList
 	protected function getOptions()
 	{
 		// Hash for caching
-		$hash = md5($this->element);
+		$hash = md5($this->element->asXML());
 		$type = strtolower($this->type);
 
 		if (!isset(static::$options[$type][$hash]) && !empty($this->predefinedOptions))


### PR DESCRIPTION
The current implementation of predefined list field caches the field using an MD5 signature on the xml element.  However, this does not permit the caching of multiple instances of the field, where the name of the field, its label, description etc might be different.  

An example of this would be the use of the predefined list as a status field in an admin-side list filter.  If a list consists of records containing multiple status fields, only the first instance will be cached, and all subsequent status fields will be rendered using the first cached version.

A list view can be created using an intermediate join table with id's from two related tables, and the status column from each related table can be displayed.

This PR uses the MD5 signature of the xml output of the element, rather than just on the element object itself.  Thus if any attributes of the field are different, a unique signature is created.

Pull Request for Issue # .

### Summary of Changes

### Testing Instructions

### Documentation Changes Required
